### PR TITLE
Fix the install exception 'ImportError: cannot import name 'Feature' …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==1.0
 idna==2.5
 itsdangerous==0.24
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1
 requests==2.20.0
 six==1.10.0
 urllib3==1.24.2


### PR DESCRIPTION
Bump the markdownsafe library version to 1.1 to fix "ImportError: cannot import name 'Feature' from 'setuptools'"

    ERROR: Command errored out with exit status 1:
     command: /Users/oisin/.virtualenvs/local-sso/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/ml/8hwzwbvx7357hfwp139jt3700000gn/T/pip-install-b80tcewt/markupsafe/setup.py'"'"'; __file__='"'"'/private/var/folders/ml/8hwzwbvx7357hfwp139jt3700000gn/T/pip-install-b80tcewt/markupsafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/ml/8hwzwbvx7357hfwp139jt3700000gn/T/pip-pip-egg-info-bkb9cqvh
         cwd: /private/var/folders/ml/8hwzwbvx7357hfwp139jt3700000gn/T/pip-install-b80tcewt/markupsafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/ml/8hwzwbvx7357hfwp139jt3700000gn/T/pip-install-b80tcewt/markupsafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature' from 'setuptools' (/Users/oisin/.virtualenvs/local-sso/lib/python3.8/site-packages/setuptools/__init__.py)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
